### PR TITLE
test enhancement, initial PHPUnit setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: php
+
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+
+matrix:
+  fast_finish: true
+
+before_script:
+  - composer install --no-interaction
+
+script:
+  - ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
   "keywords": ["router", "api", "rest", "cors"],
   "license": "MIT",
   "require": {
-    "php": "~5.6|~7.0"
+    "php": ">=5.6"
   },
   "require-dev": {
-    "phpunit/phpunit": "~5.5.0"
+    "phpunit/phpunit": "^5.5|^6.5"
   },
   "authors": [
     {
@@ -20,6 +20,11 @@
   "autoload": {
     "psr-4": {
       "Fostam\\SimpleRouter\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Fostam\\SimpleRouter\\Tests\\": "tests"
     }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+
+    <testsuites>
+        <testsuite name="getopts Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+
+</phpunit>

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -1,14 +1,13 @@
 <?php
 
+namespace Fostam\SimpleRouter\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Fostam\SimpleRouter\Processor;
 use Fostam\SimpleRouter\Route;
 use Fostam\SimpleRouter\Http;
 
-/**
- * @covers Route
- */
-final class RouteTest extends TestCase {
+class RouteTest extends TestCase {
     public function testCanBeCreated() {
         /** @var Processor|PHPUnit_Framework_MockObject_MockObject $processor*/
         $processor = $this->getMockBuilder(Processor::class)->getMock();
@@ -23,17 +22,17 @@ final class RouteTest extends TestCase {
      * @param $path
      * @param $method
      *
-     * @dataProvider testCreateExceptionsProvider
+     * @dataProvider createExceptionsProvider
      */
     public function testCreateExceptions($path, $method) {
         /** @var Processor|PHPUnit_Framework_MockObject_MockObject $processor*/
         $processor = $this->getMockBuilder(Processor::class)->getMock();
 
-        $this->expectException(Fostam\SimpleRouter\Exception\InternalApiException::class);
+        $this->expectException(\Fostam\SimpleRouter\Exception\InternalApiException::class);
         Route::create($path, $method, $processor);
     }
 
-    public function testCreateExceptionsProvider() {
+    public function createExceptionsProvider() {
         return [
             ['', Http::METHOD_GET],
             ['/test', 'test'],
@@ -132,7 +131,7 @@ final class RouteTest extends TestCase {
      * @param $inputPath
      * @param $expectedValues
      *
-     * @dataProvider testParamParsingProvider
+     * @dataProvider paramParsingProvider
      */
     public function testParamParsing($path, $inputPath, $expectedValues) {
         /** @var Processor|PHPUnit_Framework_MockObject_MockObject $processor*/
@@ -146,7 +145,7 @@ final class RouteTest extends TestCase {
     }
 
 
-    public function testParamParsingProvider() {
+    public function paramParsingProvider() {
         return [
             ['/path/{param}', '/path/test', ['param' => 'test']],
             ['/path/{param}/{test:\d+}', '/path/test/123', ['param' => 'test', 'test' => '123']],

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -1,20 +1,19 @@
 <?php
 
+namespace Fostam\SimpleRouter\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Fostam\SimpleRouter\Processor;
 use Fostam\SimpleRouter\Router;
 use Fostam\SimpleRouter\Http;
 
-/**
- * @covers Router
- */
-final class RouterTest extends TestCase {
+class RouterTest extends TestCase {
     /**
      * @param $inputPath
      * @param $inputMethod
      * @param $expectedResult
      *
-     * @dataProvider testResolveTargetProvider
+     * @dataProvider resolveTargetProvider
      */
     public function testResolveTarget($inputPath, $inputMethod, $expectedResult) {
         // build routes
@@ -44,7 +43,7 @@ final class RouterTest extends TestCase {
         $router->resolve($inputPath, $inputMethod);
     }
 
-    public function testResolveTargetProvider() {
+    public function resolveTargetProvider() {
         return [
             ['/path', Http::METHOD_GET, 1],
             ['/path', Http::METHOD_POST, 2],


### PR DESCRIPTION
# Changed log 

- initial the Travis CI build. Please see the [Travis build log](https://travis-ci.org/peter279k/php-simplerouter/builds/365060559).
- set the correct PHPUnit setting.
- add the ```autoload-dev``` class-based test namespace in ```composer.json```.